### PR TITLE
Update support for Django to 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [2.1.6][] - 2025-05-24
+
+* Update Django dependency to `>=4.0,<5.2`
+
 ## [2.1.5][] - 2024-01-26
 
 * Update Django dependency to `>=4.0,<5.0`
@@ -86,7 +90,8 @@ This is a hotfix release to fix a broken pypi build.
 
 Initial release.
 
-[unreleased]: https://github.com/cloud-gov/cg-django-uaa/compare/v2.1.5...HEAD
+[unreleased]: https://github.com/cloud-gov/cg-django-uaa/compare/v2.1.6...HEAD
+[2.1.6]: https://github.com/cloud-gov/cg-django-uaa/compare/v2.1.5...v2.1.6
 [2.1.5]: https://github.com/cloud-gov/cg-django-uaa/compare/v2.1.4...v2.1.5
 [2.1.4]: https://github.com/cloud-gov/cg-django-uaa/compare/v2.1.3...v2.1.4
 [2.1.3]: https://github.com/cloud-gov/cg-django-uaa/compare/v2.1.2...v2.1.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,8 @@ classifiers =
     Framework :: Django :: 4.0
     Framework :: Django :: 4.1
     Framework :: Django :: 4.2
+    Framework :: Django :: 5.0
+    Framework :: Django :: 5.1
     Intended Audience :: Developers
     License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
     Operating System :: OS Independent
@@ -34,6 +36,6 @@ package_dir =
     uaa_client = uaa_client
 packages = find:
 install_requires =
-    django>=4.0,<5.0
+    django>=4.0,<5.2
     PyJWT>=2.4.0
     requests>=2.11.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{8,9,10,11,12}-django{40,41,42}
+envlist = py3{8,9,10,11,12}-django{40,41,42,50,51}
 isolated_build = true
 
 [testenv:py3{8,9,10,11,12}-django40]
@@ -25,6 +25,24 @@ deps =
   -r requirements-tests.txt
   -r requirements-dev.txt
   django42: Django>=4.2,<4.3
+commands =
+  python -m uaa_client.runtests -v
+  python -m mypy uaa_client -v
+
+[testenv:py3{10,11,12}-django50]
+deps =
+  -r requirements-tests.txt
+  -r requirements-dev.txt
+  django50: Django>=5.0,<5.1
+commands =
+  python -m uaa_client.runtests -v
+  python -m mypy uaa_client -v
+
+[testenv:py3{10,11,12}-django51]
+deps =
+  -r requirements-tests.txt
+  -r requirements-dev.txt
+  django51: Django>=5.1,<5.2
 commands =
   python -m uaa_client.runtests -v
   python -m mypy uaa_client -v

--- a/uaa_client/__init__.py
+++ b/uaa_client/__init__.py
@@ -1,3 +1,3 @@
-VERSION = "2.1.5"
+VERSION = "2.1.6"
 
 default_app_config = "uaa_client.apps.UaaClientConfig"

--- a/uaa_client/tests/test_decorators.py
+++ b/uaa_client/tests/test_decorators.py
@@ -48,7 +48,7 @@ class StaffLoginRequiredTests(TestCase):
     def test_redirects_to_login(self):
         res = self.client.get(self.url)
         self.assertEqual(302, res.status_code)
-        self.assertEquals(res["Location"], self.redirect_url)
+        self.assertEqual(res["Location"], self.redirect_url)
         self.logger.info.assert_called_once_with(
             "Unauthenticated user has attempted to access is_staff view"
         )


### PR DESCRIPTION
Closes https://github.com/cloud-gov/django-uaa/issues/81

Changes proposed in this pull request:
- Update django dependency to >=4.0,<5.2
- Update code and tests for compatibility with Django 5
- Bump version to 2.1.6
- Update CHANGELOG

security considerations
There is no sensitive material in these updates. Just updating the code to support Django 5
