### PR TITLE
Fix manual test setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.10
 
 # This Dockerfile manually installs cg-django-uaa from a built
 # distribution and sets up the example app to run. It can be used
@@ -16,18 +16,18 @@ COPY requirements-tests.txt /
 
 RUN pip install -r /requirements-tests.txt
 
-COPY dist/cg-django-uaa-${version}.tar.gz /
+COPY dist/cg_django_uaa-${version}.tar.gz /
 
 WORKDIR /
 
-RUN pip install cg-django-uaa-${version}.tar.gz && \
+RUN pip install cg_django_uaa-${version}.tar.gz && \
   python -m uaa_client.runtests
 
 COPY example /example
 
 # Remove existing database from local testing, if any,
 # otherwise superuser creation below will fail
-RUN rm /example/db.sqlite3
+RUN rm /example/db.sqlite3 || true
 
 WORKDIR /example
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()

--- a/test.py
+++ b/test.py
@@ -25,7 +25,7 @@ class SimpleCommand(distutils.cmd.Command):
 class ManualTestCommand(SimpleCommand):
     description = "Run example app in a Docker container for manual testing."
 
-    SDIST_PATH = os.path.join("dist", "cg-django-uaa-{}.tar.gz".format(VERSION))
+    SDIST_PATH = os.path.join("dist", "cg_django_uaa-{}.tar.gz".format(VERSION))
 
     def run(self):
         if not os.path.exists(self.SDIST_PATH):


### PR DESCRIPTION
## Changes proposed in this pull request:

- [add setup.py to install dependencies from setup.cfg](https://github.com/cloud-gov/django-uaa/commit/8fbdfd556fd9cadb5d12644b19bd0ec9fb610790)
- [fix path to built distribution for package & update testing Dockerfile base image to python:3.10](https://github.com/cloud-gov/django-uaa/commit/28334b4d09bd766450e42f812446c3229d506f52) 

## security considerations

None, just changes to support testing
