### PR TITLE
remove on_success slack notifications

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -60,15 +60,6 @@ jobs:
         channel: ((slack-failure-channel))
         username: ((slack-username))
         icon_url: ((slack-icon-url))
-  on_success:
-    put: slack
-    params:
-        text: |
-            :white_check_mark: Successfully released cg-django-uaa
-            <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: ((slack-success-channel))
-        username: ((slack-username))
-        icon_url: ((slack-icon-url))
 
 resources:
 - name: cg-django-uaa-pr


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove on_success slack notifications. Slack notifications notifying success require no action and just produce noise

## security considerations

Removing notifications on job success in Slack has no security impact
