### PR TITLE
fix Django version constraint for tox

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -57,7 +57,7 @@ jobs:
         text: |
             :x: FAILED to release cg-django-uaa
             <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: ((slack-failure-channel))
+        channel: ((slack-channel-customer-success))
         username: ((slack-username))
         icon_url: ((slack-icon-url))
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ isolated_build = true
 deps =
   -r requirements-tests.txt
   -r requirements-dev.txt
-  django52: Django>5.1,<6
+  django52: Django>5,<=5.2
 commands =
   python -m uaa_client.runtests -v
   python -m mypy uaa_client -v


### PR DESCRIPTION
## Changes proposed in this pull request:

- improve Django version constraint for tox to only allow Django versions up to 5.2

## security considerations

None. Ensures that we are only testing exactly Django version 5.2
