### PR TITLE
Update Django version constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [2.1.10][] - 2026-04-01
+
+* Update Django version constraint to `django>=5.2,<6`
+
 ## [2.1.9][] - 2026-03-27
 
-* Update Django dependency to `django>5,<=5.2`
+* Update Django version constraint to `django>5,<=5.2`
 
 ## [2.1.8][] - 2025-05-23
 
@@ -102,7 +106,8 @@ This is a hotfix release to fix a broken pypi build.
 
 Initial release.
 
-[unreleased]: https://github.com/cloud-gov/cg-django-uaa/compare/v2.1.6...HEAD
+[unreleased]: https://github.com/cloud-gov/cg-django-uaa/compare/v2.1.10...HEAD
+[2.1.10]: https://github.com/cloud-gov/cg-django-uaa/compare/v2.1.9...v2.1.10
 [2.1.9]: https://github.com/cloud-gov/cg-django-uaa/compare/v2.1.8...v2.1.9
 [2.1.8]: https://github.com/cloud-gov/cg-django-uaa/compare/v2.1.7...v2.1.8
 [2.1.7]: https://github.com/cloud-gov/cg-django-uaa/compare/v2.1.6...v2.1.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,6 @@ package_dir =
     uaa_client = uaa_client
 packages = find:
 install_requires =
-    django>5,<=5.2
+    django>=5.2,<6
     PyJWT>=2.4.0
     requests>=2.11.0

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ isolated_build = true
 deps =
   -r requirements-tests.txt
   -r requirements-dev.txt
-  django52: Django>5,<=5.2
+  django52: Django>=5.2,<5.3
 commands =
   python -m uaa_client.runtests -v
   python -m mypy uaa_client -v

--- a/uaa_client/__init__.py
+++ b/uaa_client/__init__.py
@@ -1,3 +1,3 @@
-VERSION = "2.1.9"
+VERSION = "2.1.10"
 
 default_app_config = "uaa_client.apps.UaaClientConfig"


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update Django version constraint to `>=5.2,<6`, [since 5.2 is now the LTS release of Django](https://www.djangoproject.com/download/)
- Bump package version to 2.1.10
- Update CHANGELOG

## security considerations

Django 5.2.x is the LTS release of Django which is actively receiving patches and security fixes
